### PR TITLE
include vault token as a secret, fixes #9

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -239,7 +239,7 @@ describe('mycro-secrets', function() {
                 delete axios.defaults.adapter;
                 expect(err).to.not.exist;
                 expect(mycro.secrets).to.be.a('function');
-                expect(mycro.secrets()).to.have.all.keys('bugsnag', 'mongo');
+                expect(mycro.secrets()).to.have.all.keys('bugsnag', 'mongo', 'vault');
                 expect(mycro.secrets('bugsnag.api-key')).to.equal('abcdefg123');
                 expect(mycro.secrets('mongo.url')).to.equal('mongodb://localhost:27017/my-db');
                 done();


### PR DESCRIPTION
makes vault token available at `mycro.secrets('vault.token')` if no other secret is set at path `vault`
